### PR TITLE
Changed all event names to constants

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,26 @@ class Site extends EventEmitter {
   
   constructor() {
     
-		super()
+    super()
+    this.EVENTS = {
+      LOADED: 'loaded',
+      READY: 'ready',
+      AFTER_WIDGETS_INIT: 'afterWidgetsInit',
+      XHR_LOAD_START: 'xhrLoadStart',
+      XHR_TRANSITIONING_OUT: 'xhrTransitioningOut',
+      XHR_LOAD_MIDDLE: 'xhrLoadMiddle',
+      XHR_LOAD_END: 'xhrLoadEnd',
+      XHR_WILL_TRANSITION: 'xhrWillTransition',
+      XHR_WILL_TRANSITION_OUT: 'xhrWillTransitionOut',
+      XHR_WILL_SWAP_CONTENT: 'xhrWillSwapContent',
+      XHR_WILL_TRANSITION_WIDGETS_IN: 'xhrWillTransitionWidgetsIn',
+      XHR_WILL_SCROLL_TO_PREV_POSITION: 'xhrWillScrollToPrevPosition',
+      XHR_PAGE_CHANGED: 'xhrPageChanged',
+      XHR_LOADING_START: 'xhrLoadingStart',
+      XHR_LOADING_STOP: 'xhrLoadingStop',
+      XHR_POP_STATE: 'xhrPopState',
+      XHR_LINK_CLICK: 'xhrLinkClick',
+    }
     
     const size = 40
 		const style = `
@@ -36,7 +55,7 @@ class Site extends EventEmitter {
 			background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg class='header-logo' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' x='0px' y='0px' viewBox='0 0 84 45' enable-background='new 0 0 84 45' xml:space='preserve'%3e%3cstyle%3e %23ED_Logo%7btransition: transform 0.3s;%7d %23ED_Logo:hover%7btransform: scale(1.1);%7d %3c/style%3e%3cg id='ED_Logo'%3e%3cg%3e%3cpath d='M11.4,34.4h19.2V45H0V0h30.6v10.6H11.4v6.6h18.8v10.7H11.4V34.4z'%3e%3c/path%3e%3cpath d='M51.1,0c15.3,0,23,11.3,23,22.6c0,11.2-7.7,22.4-23,22.4H33.6V0H51.1z M51.1,34.5c7.8,0,11.8-6,11.8-12 c0-5.9-4-12.2-11.8-12.2h-6.2v24.1C44.9,34.5,48.2,34.5,51.1,34.5z'%3e%3c/path%3e%3cpath d='M84,39.3c0,2.8-2.6,5.7-6.2,5.7c-3.3,0-6-2.9-6-5.7c0-3.4,2.7-5.7,6-5.7C81.4,33.6,84,35.9,84,39.3z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e");
 			background-repeat:no-repeat;
 			background-position:center;
-		`
+    `
 		console.log('%c\n', style, '\nSite by ED.\nhttps://ed.com.au');
 
     this.$ = jQuery
@@ -114,10 +133,10 @@ class Site extends EventEmitter {
     this.initWidgets()
     this.initXHRPageSystem()
     this.preloadWidgets($(document.body), () => {
-      this.emit('loaded')
+      this.emit(this.EVENTS.LOADED)
     })
     this.transitionWidgetsIn($(document.body), this.pageState, { initial: true }, () => {})
-    this.emit('ready')
+    this.emit(this.EVENTS.READY)
   }
   
   initLiveReload() {
@@ -295,7 +314,7 @@ class Site extends EventEmitter {
       
     })
     
-    this.emit('afterWidgetsInit')
+    this.emit(this.EVENTS.AFTER_WIDGETS_INIT)
     
   }
   
@@ -604,14 +623,14 @@ class Site extends EventEmitter {
   		})
     }
 		
-		this.emit("xhrLoadStart")
+		this.emit(this.EVENTS.XHR_LOAD_START)
 		
 		this.getContent(originalURL, (response, textStatus) => {
 			if(requestID !== this.XHRRequestCounter) {
 				// Looks like another request was made after this one, so ignore the response.
 				return
 			}
-			this.emit("xhrTransitioningOut")
+			this.emit(this.EVENTS.XHR_TRANSITIONING_OUT)
 			
 			// Alter the response to keep the body tag
 			response = response.replace(/(<\/?)body/g, '$1bodyfake')
@@ -633,10 +652,10 @@ class Site extends EventEmitter {
 			// Grab content
 			var newContent = $("<div class='xhr-page-contents'></div>").append(foundPageContainer.children())
 			
-			this.emit("xhrLoadMiddle")
+			this.emit(this.EVENTS.XHR_LOAD_MIDDLE)
 			
 			var finalize = () => {
-				this.emit("xhrLoadEnd")
+				this.emit(this.EVENTS.XHR_LOAD_END)
 				
 				// Grab the page title
 				var title = result.find("title").html()
@@ -775,7 +794,7 @@ class Site extends EventEmitter {
           }
 				}
         
-        this.emit('xhrWillTransition')
+        this.emit(this.EVENTS.XHR_WILL_TRANSITION)
 				
 				// Destroy existing widgets
 				var steps = [
@@ -798,15 +817,15 @@ class Site extends EventEmitter {
 						newContent.hide()
 						
 						// Perform the swap!
-            this.emit('xhrWillSwapContent')
+            this.emit(this.EVENTS.XHR_WILL_SWAP_CONTENT)
 						var delay = this.xhrOptions.widgetTransitionDelay
 						delay = this.xhrOptions.swapContent(this.XHRPageContainer, oldContent, newContent, dontPush ? "back" : "forward") || delay
 						setTimeout(next, delay)
 					},
 					(next) => {
-						this.emit('xhrWillTransitionWidgetsIn')
+						this.emit(this.EVENTS.XHR_WILL_TRANSITION_WIDGETS_IN)
 						if(history.state && typeof history.state.scrollY === 'number' && !history.state.dontAutoScroll){
-              this.emit('xhrWillScrollToPrevPosition')
+              this.emit(this.EVENTS.XHR_WILL_SCROLL_TO_PREV_POSITION)
 							$('html, body').animate({scrollTop: history.state.scrollY}, 0)
 						}
 						this.transitionWidgetsIn(newContent, this.pageState, oldPageState, next)
@@ -818,7 +837,7 @@ class Site extends EventEmitter {
 					if(stepIndex < steps.length) {
 						steps[stepIndex++](next)
 					} else {
-						this.emit("xhrPageChanged")
+						this.emit(this.EVENTS.XHR_PAGE_CHANGED)
 					}
 				}
 				
@@ -956,10 +975,10 @@ class Site extends EventEmitter {
 		// Add event listeners to jQuery which will add/remove the 'xhr-loading' class
 		$(document).ajaxStart(() => {
 			$(document.body).addClass("xhr-loading")
-			this.emit("xhrLoadingStart")
+			this.emit(this.EVENTS.XHR_LOAD_START)
 		}).ajaxStop(() => {
 			$(document.body).removeClass("xhr-loading")
-			this.emit("xhrLoadingStop")
+			this.emit(this.EVENTS.XHR_LOADING_STOP)
 		})
 		
 		// Add event listeners to links where appropriate
@@ -976,7 +995,7 @@ class Site extends EventEmitter {
         e.preventDefault = () => {
           wasDefaultPrevented = true
         }
-        this.emit('xhrPopState', e)
+        this.emit(this.EVENTS.XHR_POP_STATE, e)
         if(!wasDefaultPrevented) {
   				this.goToURL(window.location.href, true)
         }
@@ -1026,7 +1045,7 @@ class Site extends EventEmitter {
 			
 			linkEl.click((e) => {
 				if(!e.metaKey && !e.ctrlKey) {
-					this.emit('xhrLinkClick', e, $(linkEl))
+					this.emit(this.EVENTS.XHR_LINK_CLICK, e, $(linkEl))
           // A dev can use e.preventDefault() to also prevent any XHR transitions!
           if(!e.isDefaultPrevented()) {
             e.preventDefault()


### PR DESCRIPTION
All events used by this.emit are in an object called this.EVENTS so now you can (dont have to) write: 
```javascript
this.emit(this.EVENTS.XHR_LOAD_START)
// or
Site.on(Site.EVENTS.XHR_LOAD_START)
```
but most importantly you can now `console.log(Site.EVENTS)` to see all the events you can hook into